### PR TITLE
feat(npmignore) npm 배포 예외 파일 추가

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,8 @@
+.vscode/
+.github/
+.eslintrc
+eslint.config.js
+.prettierrc
+.prettierignore
+pnpm-lock.yaml
+*.log

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align="center">
   <br>
-  <img src="https://github.com/user-attachments/assets/f42b3836-ac28-4d8a-9d20-bdbd7cc7d8b5" alt="Project Logo" width="140" />
+  <img src="https://github.com/user-attachments/assets/f42b3836-ac28-4d8a-9d20-bdbd7cc7d8b5" alt="Project Logo" width="800" />
   <br>
   <br>
   PackMate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "packmate",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Your smart and friendly assistant for dependency updates and cleanup.",
   "author": "AGUMON <ljlm0402@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
npm에 publish(배포)할 때, 프로젝트에 불필요한 파일/폴더(예: .vscode, .github, 테스트, 설정 파일 등)가 포함되지 않게 하려는 대표적인 방법.